### PR TITLE
Prevent logging of request paths in non-debug mode

### DIFF
--- a/src/main/java/org/cryptomator/webdav/core/filters/LoggingFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/LoggingFilter.java
@@ -19,6 +19,9 @@ import java.util.concurrent.atomic.AtomicLong;
 public class LoggingFilter implements HttpFilter {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LoggingFilter.class);
+
+	public static final String REQUEST_ID_ATTR_NAME = "org.cryptomator.requestId";
+
 	private final AtomicLong REQUEST_ID_GEN = new AtomicLong();
 
 	@Override
@@ -26,6 +29,7 @@ public class LoggingFilter implements HttpFilter {
 		if (LOG.isDebugEnabled()) {
 			long requestId = REQUEST_ID_GEN.getAndIncrement();
 			LOG.debug("REQUEST {}:\n{} {} {}\n{}", requestId, request.getMethod(), request.getRequestURI(), request.getProtocol(), headers(request));
+			request.setAttribute(REQUEST_ID_ATTR_NAME, requestId);
 			chain.doFilter(request, response);
 			LOG.debug("RESPONSE {}:\n{}\n{}", requestId, response.getStatus(), headers(response));
 		} else {

--- a/src/main/java/org/cryptomator/webdav/core/servlet/AbstractNioWebDavServlet.java
+++ b/src/main/java/org/cryptomator/webdav/core/servlet/AbstractNioWebDavServlet.java
@@ -17,11 +17,13 @@ import org.apache.jackrabbit.webdav.lock.ActiveLock;
 import org.apache.jackrabbit.webdav.lock.Scope;
 import org.apache.jackrabbit.webdav.lock.Type;
 import org.apache.jackrabbit.webdav.server.AbstractWebdavServlet;
+import org.cryptomator.webdav.core.filters.LoggingFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -96,12 +98,21 @@ public abstract class AbstractNioWebDavServlet extends AbstractWebdavServlet {
 			} catch (UncheckedDavException e) {
 				throw e.toDavException();
 			}
+		} catch (IOException | UncheckedIOException e) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("REQUEST {}: Returning 500 due to IO exception.", request.getAttribute(LoggingFilter.REQUEST_ID_ATTR_NAME), e);
+			} else {
+				LOG.warn("{} request failed, returning 500. Reason: {}", DavMethodsUtil.getName(method), e.getClass().getName());
+			}
+			response.sendError(DavServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
 		} catch (DavException e) {
 			if (e.getErrorCode() == DavServletResponse.SC_INTERNAL_SERVER_ERROR) {
 				LOG.error("Unexpected DavException.", e);
 			}
+			LOG.debug("REQUEST {}: Returning {} due to exception.", request.getAttribute(LoggingFilter.REQUEST_ID_ATTR_NAME), e.getErrorCode(), e);
 			throw e;
 		}
+		return true;
 	}
 
 	/* GET stuff */

--- a/src/main/java/org/cryptomator/webdav/core/servlet/DavMethodsUtil.java
+++ b/src/main/java/org/cryptomator/webdav/core/servlet/DavMethodsUtil.java
@@ -1,0 +1,88 @@
+package org.cryptomator.webdav.core.servlet;
+
+import org.apache.jackrabbit.webdav.DavMethods;
+
+class DavMethodsUtil {
+
+	private DavMethodsUtil() {}
+
+	/**
+	 * Returns for the given DAV method code the method name.
+	 *
+	 * @param code DAV method code as defined in {@link DavMethods}
+	 * @return DAV method name
+	 */
+	static String getName(int code) {
+		switch (code) {
+			case DavMethods.DAV_GET:
+				return DavMethods.METHOD_GET;
+			case DavMethods.DAV_HEAD:
+				return DavMethods.METHOD_HEAD;
+			case DavMethods.DAV_PROPFIND:
+				return DavMethods.METHOD_PROPFIND;
+			case DavMethods.DAV_PROPPATCH:
+				return DavMethods.METHOD_PROPPATCH;
+			case DavMethods.DAV_POST:
+				return DavMethods.METHOD_POST;
+			case DavMethods.DAV_PUT:
+				return DavMethods.METHOD_PUT;
+			case DavMethods.DAV_DELETE:
+				return DavMethods.METHOD_DELETE;
+			case DavMethods.DAV_COPY:
+				return DavMethods.METHOD_COPY;
+			case DavMethods.DAV_MOVE:
+				return DavMethods.METHOD_MOVE;
+			case DavMethods.DAV_MKCOL:
+				return DavMethods.METHOD_MKCOL;
+			case DavMethods.DAV_OPTIONS:
+				return DavMethods.METHOD_OPTIONS;
+			case DavMethods.DAV_LOCK:
+				return DavMethods.METHOD_LOCK;
+			case DavMethods.DAV_UNLOCK:
+				return DavMethods.METHOD_UNLOCK;
+			case DavMethods.DAV_ORDERPATCH:
+				return DavMethods.METHOD_ORDERPATCH;
+			case DavMethods.DAV_SUBSCRIBE:
+				return DavMethods.METHOD_SUBSCRIBE;
+			case DavMethods.DAV_UNSUBSCRIBE:
+				return DavMethods.METHOD_UNSUBSCRIBE;
+			case DavMethods.DAV_POLL:
+				return DavMethods.METHOD_POLL;
+			case DavMethods.DAV_SEARCH:
+				return DavMethods.METHOD_SEARCH;
+			case DavMethods.DAV_VERSION_CONTROL:
+				return DavMethods.METHOD_VERSION_CONTROL;
+			case DavMethods.DAV_LABEL:
+				return DavMethods.METHOD_LABEL;
+			case DavMethods.DAV_REPORT:
+				return DavMethods.METHOD_REPORT;
+			case DavMethods.DAV_CHECKIN:
+				return DavMethods.METHOD_CHECKIN;
+			case DavMethods.DAV_CHECKOUT:
+				return DavMethods.METHOD_CHECKOUT;
+			case DavMethods.DAV_UNCHECKOUT:
+				return DavMethods.METHOD_UNCHECKOUT;
+			case DavMethods.DAV_MERGE:
+				return DavMethods.METHOD_MERGE;
+			case DavMethods.DAV_UPDATE:
+				return DavMethods.METHOD_UPDATE;
+			case DavMethods.DAV_MKWORKSPACE:
+				return DavMethods.METHOD_MKWORKSPACE;
+			case DavMethods.DAV_MKACTIVITY:
+				return DavMethods.METHOD_MKACTIVITY;
+			case DavMethods.DAV_BASELINE_CONTROL:
+				return DavMethods.METHOD_BASELINE_CONTROL;
+			case DavMethods.DAV_ACL:
+				return DavMethods.METHOD_ACL;
+			case DavMethods.DAV_REBIND:
+				return DavMethods.METHOD_REBIND;
+			case DavMethods.DAV_UNBIND:
+				return DavMethods.METHOD_UNBIND;
+			case DavMethods.DAV_BIND:
+				return DavMethods.METHOD_BIND;
+			default:
+				// any other method
+				return "UNKNOWN";
+		}
+	}
+}


### PR DESCRIPTION
This PR is similar to https://github.com/cryptomator/fuse-nio-adapter/pull/207.

It prevents unintended leaking of cleartext paths into the log. Only if debug mode is activated, the stacktrace is logged. Otherwise only warning is logged when an IOException occurs. 