### PR TITLE
Feature: Migrate to Jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
 		<!-- dependencies -->
 		<servlet.version>6.0.0</servlet.version>
-		<jackrabbit.version>2.22.4</jackrabbit.version>
+		<jackrabbit.version>2.22.4-SNAPSHOT</jackrabbit.version>
 		<guava.version>33.6.0-jre</guava.version>
 		<slf4j.version>2.0.18</slf4j.version>
 
@@ -305,4 +305,20 @@
 			</distributionManagement>
 		</profile>
 	</profiles>
+
+	<repositories>
+		<repository>
+			<name>Central Portal Snapshots</name>
+			<id>central-portal-snapshots</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+</repositories>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.cryptomator</groupId>
 	<artifactId>webdav-nio-adapter-servlet</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>WebDAV-NIO Adapter Servlet</name>
 	<description>Servlet serving NIO directory contents as WebDAV resources.</description>
 	<url>https://github.com/cryptomator/webdav-nio-adapter-servlet</url>
@@ -18,8 +18,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- dependencies -->
-		<servlet.version>4.0.1</servlet.version>
-		<jackrabbit.version>2.22.3</jackrabbit.version>
+		<servlet.version>6.0.0</servlet.version>
+		<jackrabbit.version>2.22.4</jackrabbit.version>
 		<guava.version>33.6.0-jre</guava.version>
 		<slf4j.version>2.0.18</slf4j.version>
 
@@ -61,14 +61,16 @@
 	<dependencies>
 		<!-- Jackrabbit -->
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<version>${servlet.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.jackrabbit</groupId>
-			<artifactId>jackrabbit-webdav</artifactId>
+			<!-- jakarta.servlet repackaging of org.apache.jackrabbit:jackrabbit-webdav,
+			 interim solution until jackrabbit ships jakarta support (JCR-4892) -->
+			<groupId>org.cryptomator</groupId>
+			<artifactId>jackrabbit-webdav-jakarta</artifactId>
 			<version>${jackrabbit.version}</version>
 			<exclusions>
 				<exclusion>
@@ -286,5 +288,4 @@
 			</distributionManagement>
 		</profile>
 	</profiles>
-
 </project>

--- a/src/main/java/org/cryptomator/webdav/core/filters/AcceptRangeFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/AcceptRangeFilter.java
@@ -8,11 +8,11 @@
  *******************************************************************************/
 package org.cryptomator.webdav.core.filters;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/src/main/java/org/cryptomator/webdav/core/filters/HttpFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/HttpFilter.java
@@ -8,9 +8,9 @@
  *******************************************************************************/
 package org.cryptomator.webdav.core.filters;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 interface HttpFilter extends Filter {

--- a/src/main/java/org/cryptomator/webdav/core/filters/LoggingFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/LoggingFilter.java
@@ -8,10 +8,10 @@ package org.cryptomator.webdav.core.filters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/main/java/org/cryptomator/webdav/core/filters/MacChunkedPutCompatibilityFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/MacChunkedPutCompatibilityFilter.java
@@ -10,13 +10,13 @@ package org.cryptomator.webdav.core.filters;
 
 import com.google.common.io.ByteStreams;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ReadListener;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/src/main/java/org/cryptomator/webdav/core/filters/MkcolComplianceFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/MkcolComplianceFilter.java
@@ -11,10 +11,10 @@ package org.cryptomator.webdav.core.filters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/src/main/java/org/cryptomator/webdav/core/filters/PostRequestBlockingFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/PostRequestBlockingFilter.java
@@ -11,11 +11,11 @@ package org.cryptomator.webdav.core.filters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
 
 import static java.util.Arrays.stream;

--- a/src/main/java/org/cryptomator/webdav/core/filters/UnicodeResourcePathNormalizationFilter.java
+++ b/src/main/java/org/cryptomator/webdav/core/filters/UnicodeResourcePathNormalizationFilter.java
@@ -5,20 +5,19 @@
  *******************************************************************************/
 package org.cryptomator.webdav.core.filters;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.jackrabbit.webdav.DavServletResponse;
 import org.apache.jackrabbit.webdav.util.EncodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.WriteListener;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import javax.xml.namespace.QName;
 import javax.xml.stream.*;
 import java.io.*;
@@ -38,7 +37,7 @@ public class UnicodeResourcePathNormalizationFilter implements HttpFilter {
 	private static final Logger LOG = LoggerFactory.getLogger(UnicodeResourcePathNormalizationFilter.class);
 	private static final String PROPFIND_METHOD = "PROPFIND";
 	private static final String USER_AGENT_HEADER = "User-Agent";
-	private static final Set<String> USER_AGENTS_EXPECTING_NFD = ImmutableSet.of("WebDAVFS");
+	private static final Set<String> USER_AGENTS_EXPECTING_NFD = Set.of("WebDAVFS");
 
 	@Override
 	public void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/src/main/java/org/cryptomator/webdav/core/servlet/AbstractNioWebDavServlet.java
+++ b/src/main/java/org/cryptomator/webdav/core/servlet/AbstractNioWebDavServlet.java
@@ -9,7 +9,6 @@
 package org.cryptomator.webdav.core.servlet;
 
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import org.apache.jackrabbit.webdav.*;
 import org.apache.jackrabbit.webdav.header.IfHeader;
@@ -21,7 +20,7 @@ import org.cryptomator.webdav.core.filters.LoggingFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -167,7 +166,7 @@ public abstract class AbstractNioWebDavServlet extends AbstractWebdavServlet {
 	private boolean hasCorrectLockTokens(DavSession session, DavResource resource) {
 		boolean access = false;
 
-		final Set<String> providedLockTokens = ImmutableSet.copyOf(session.getLockTokens());
+		final Set<String> providedLockTokens = Set.of(session.getLockTokens());
 		for (ActiveLock lock : resource.getLocks()) {
 			access |= providedLockTokens.contains(lock.getToken());
 		}

--- a/src/main/java/org/cryptomator/webdav/core/servlet/DavResourceFactoryImpl.java
+++ b/src/main/java/org/cryptomator/webdav/core/servlet/DavResourceFactoryImpl.java
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.cryptomator.webdav.core.servlet;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.jackrabbit.webdav.*;
 import org.apache.jackrabbit.webdav.lock.LockManager;
 
@@ -22,6 +21,7 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 class DavResourceFactoryImpl implements DavResourceFactory {
@@ -98,7 +98,7 @@ class DavResourceFactoryImpl implements DavResourceFactory {
 
 	private DavResource createDestinationResource(DavLocatorImpl locator, DavServletRequest request, DavServletResponse response) throws DavException {
 		assert locator.equals(request.getDestinationLocator());
-		assert ImmutableSet.of(DavMethods.METHOD_MOVE, DavMethods.METHOD_COPY).contains(request.getMethod());
+		assert Set.of(DavMethods.METHOD_MOVE, DavMethods.METHOD_COPY).contains(request.getMethod());
 		Path srcP = resolveUrl(request.getRequestLocator().getResourcePath());
 		Path dstP = resolveUrl(locator.getResourcePath());
 		Optional<BasicFileAttributes> srcAttr = readBasicFileAttributes(srcP);

--- a/src/main/java/org/cryptomator/webdav/core/servlet/NioWebDavServlet.java
+++ b/src/main/java/org/cryptomator/webdav/core/servlet/NioWebDavServlet.java
@@ -1,6 +1,6 @@
 package org.cryptomator.webdav.core.servlet;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/src/test/java/org/cryptomator/webdav/core/filters/MacChunkedPutCompatibilityFilterTest.java
+++ b/src/test/java/org/cryptomator/webdav/core/filters/MacChunkedPutCompatibilityFilterTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class MacChunkedPutCompatibilityFilterTest {

--- a/src/test/java/org/cryptomator/webdav/core/filters/UnicodeResourcePathNormalizationFilterTest.java
+++ b/src/test/java/org/cryptomator/webdav/core/filters/UnicodeResourcePathNormalizationFilterTest.java
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;


### PR DESCRIPTION
This PR updates the library to use the Jakarta 6.0 specification.

Closes #46.

It uses a migrated re-release of jackrabbit-webdav, see https://github.com/cryptomator/jackrabbit-webdav-jakarta for more details.